### PR TITLE
ci: apt-get update first

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -31,11 +37,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          show-progress: false
 
       - name: Install module
         run: pip install .[tests]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install libkrb5 for Kerberos on Linux
         run: |
-          sudo apt install -y libkrb5-dev
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
           pip install requests-kerberos
 
       - name: Checkout code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,14 +24,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          # cache: pip
-          # cache-dependency-path: setup.py
+          cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install libkrb5 for Kerberos on Linux
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-          pip install requests-kerberos
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Quick update to the schedule lead to the build failing on the libkrb-5 install. Now doing an `apt-get update` beforehand as best practice.