### PR TITLE
Check if upload gdb item already exists in AGOL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,7 @@
         "--no-cov"
     ],
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",

--- a/setup.py
+++ b/setup.py
@@ -38,21 +38,21 @@ setup(
     },
     keywords=["gis"],
     install_requires=[
-        "ugrc-palletjack==4.3.*",
+        "ugrc-palletjack>=4.2,<4.4",
         "agrc-supervisor==3.0.*",
     ],
     extras_require={
         "tests": [
             "pylint-quotes~=0.2",
             "pylint>=2.11,<4.0",
-            "pytest-cov>=3,<5",
+            "pytest-cov>=3,<6",
             "pytest-instafail~=0.4",
-            "pytest-isort>=2,<4",
+            "pytest-isort>=2,<5",
             "pytest-pylint~=0.18",
             "pytest-watch~=4.2",
-            "pytest>=6,<8",
-            "black>=23.3,<23.12",
-            "pytest-mock>=3.10,<3.13",
+            "pytest>=6,<9",
+            "black>=23.3,<24.4",
+            "pytest-mock>=3.10,<3.15",
             "functions-framework",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     },
     keywords=["gis"],
     install_requires=[
-        "ugrc-palletjack==4.2.*",
+        "ugrc-palletjack==4.3.*",
         "agrc-supervisor==3.0.*",
     ],
     extras_require={

--- a/src/nfhl/main.py
+++ b/src/nfhl/main.py
@@ -241,7 +241,7 @@ def _update_hazard_layer_symbology(gis):
 
 
 def _delete_existing_gdb_item(gis, gdb_item_name, module_logger):
-    module_logger.info("Trying to delete existing GDB item '%s'...", gdb_item_name)
+    module_logger.info("Searching for and deleting GDB item '%s' if needed...", gdb_item_name)
 
     searches = gis.content.search(query=gdb_item_name, item_type="File Geodatabase")
     if not searches:


### PR DESCRIPTION
If the upload gdb item already exists, palletjack bombs out when trying to upload the new data, but only after it has already truncated all the existing data. If one layer fails and the upload gdb item remains, then all further layers will be truncated and then fail to update because of the gdb item.

This adds a check prior to truncate and loading that looks for and attempts to delete the gdb item and errors out if it can't.  