### PR TITLE
Delete all existing scheduler jobs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -134,23 +134,16 @@ jobs:
 
       - name: 🕰️ Create Cloud Scheduler
         run: |
-          if [ ! "$(gcloud scheduler jobs list --location=us-central1 | grep saturday-evening2)" ]; then
-            gcloud scheduler jobs create http saturday-evening2 \
-              --description="Trigger the nfhl-skid bot once a week on saturday evening" \
-              --schedule="0 3 * * 6" \
-              --time-zone=America/Denver \
-              --location=us-central1 \
-              --uri="https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${{ secrets.PROJECT_ID }}/jobs/default:run" \
-              --oauth-service-account-email=scheduler-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
-          else
-            gcloud scheduler jobs update http saturday-evening2 \
-              --description="Trigger the nfhl-skid bot once a week on saturday evening" \
-              --schedule="0 3 * * 6" \
-              --time-zone=America/Denver \
-              --location=us-central1 \
-              --uri="https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${{ secrets.PROJECT_ID }}/jobs/default:run" \
-              --oauth-service-account-email=scheduler-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
-          fi
+          for i in $(gcloud scheduler jobs list --location=us-central1 --uri); do
+            gcloud scheduler jobs delete $i --quiet
+          done
+          gcloud scheduler jobs create http saturday-evening \
+            --description="Trigger the nfhl-skid bot once a week on saturday evening" \
+            --schedule="0 3 * * 6" \
+            --time-zone=America/Denver \
+            --location=us-central1 \
+            --uri="https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${{ secrets.PROJECT_ID }}/jobs/default:run" \
+            --oauth-service-account-email=scheduler-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
 
   deploy-prod:
     name: Deploy to Cloud Run (prod)

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -135,8 +134,8 @@ jobs:
 
       - name: 🕰️ Create Cloud Scheduler
         run: |
-          if [ ! "$(gcloud scheduler jobs list --location=us-central1 | grep saturday-evening)" ]; then
-            gcloud scheduler jobs create http saturday-evening \
+          if [ ! "$(gcloud scheduler jobs list --location=us-central1 | grep saturday-evening2)" ]; then
+            gcloud scheduler jobs create http saturday-evening2 \
               --description="Trigger the nfhl-skid bot once a week on saturday evening" \
               --schedule="0 3 * * 6" \
               --time-zone=America/Denver \
@@ -144,7 +143,7 @@ jobs:
               --uri="https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${{ secrets.PROJECT_ID }}/jobs/default:run" \
               --oauth-service-account-email=scheduler-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
           else
-            gcloud scheduler jobs update http saturday-evening \
+            gcloud scheduler jobs update http saturday-evening2 \
               --description="Trigger the nfhl-skid bot once a week on saturday evening" \
               --schedule="0 3 * * 6" \
               --time-zone=America/Denver \


### PR DESCRIPTION
Here's my first attempt at keeping the scheduler jobs clean by always nuking everything and creating a new job every deploy. Thoughts?
 