### PR TITLE
fix: pin arcgis to fix gdb write problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 setup.py
 A module that installs the nfhl-skid skid as a module
 """
+
 from glob import glob
 from os.path import basename, splitext
 
@@ -40,6 +41,7 @@ setup(
     install_requires=[
         "ugrc-palletjack>=5.0,<5.3",
         "ugrc-supervisor>=3.1.3",
+        "arcgis==2.4.0",  #: Polygon dataframes aren't writing to gdb with 2.4.1.1
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
After the latest dbot updates, the polygon datasets were failing to update due to an error writing them out to the gdb then zipped and uploaded to AGOL for the append step. Pinning `arcgis==2.4.0` seems to solve the problem. 

The latest versions of `arcgis` also has problems with [projecting when using pyproj](https://github.com/Esri/arcgis-python-api/issues/2303), so this may be related.